### PR TITLE
Handled socket.io production

### DIFF
--- a/src/components/line_animations.jsx
+++ b/src/components/line_animations.jsx
@@ -32,6 +32,7 @@ const LineAnime = (props) => {
                             top: 0,
                             transition: {
                                 duration: duration,
+                                
                                 ease: easeIn,
                                 repeat: Infinity,
                                 repeatType: "reverse",

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,6 +1,6 @@
 import io  from "socket.io-client";
 
-export const socket = io("ws://localhost:4400", {
+export const socket = io("wss://api.socialxai-api.net", {
     transports: ["websocket"],
     autoConnect: false,
     path: "/io"


### PR DESCRIPTION
Revert back to production URL. This should probably be done using a more dynamic method to prevent forgetting setting it up